### PR TITLE
Improved carousel UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
       justify-content: center;
       border: none;
     }
-    .fullscreen-arrow {
+      .fullscreen-arrow {
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
@@ -196,52 +196,47 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 32px;
-    }
-    .carousel-arrow {
-      background: rgba(0, 0, 0, 0.5);
-      color: #fff;
-      border: none;
-      font-size: 2em;
-      width: 48px;
-      height: 48px;
-      border-radius: 50%;
-      cursor: pointer;
-      z-index: 2;
-      transition: background 0.2s;
-    }
-    .carousel-arrow:hover {
-      background: rgba(0, 0, 0, 0.8);
+      gap: 0;
     }
     .carousel-slider {
-      overflow: hidden;
+      overflow: visible;
       width: 100%;
       max-width: 500px;
       min-height: 350px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
       position: relative;
+      perspective: 1000px;
     }
     .carousel-slide {
-      min-width: 100%;
-      box-sizing: border-box;
-      display: none;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 70%;
+      transform: translate(-50%, -50%) scale(0.7);
+      display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      height: 100%;
-      transition: opacity 0.5s;
+      pointer-events: none;
+      opacity: 0;
+      transition: transform 0.6s ease, opacity 0.6s ease;
     }
     .carousel-slide.active {
-      display: flex;
-      position: relative;
+      transform: translate(-50%, -50%) scale(1);
       opacity: 1;
-      z-index: 1;
+      z-index: 3;
+      pointer-events: auto;
+    }
+    .carousel-slide.prev {
+      transform: translate(-130%, -50%) scale(0.8) rotateY(20deg);
+      opacity: 1;
+      z-index: 2;
+      pointer-events: auto;
+    }
+    .carousel-slide.next {
+      transform: translate(30%, -50%) scale(0.8) rotateY(-20deg);
+      opacity: 1;
+      z-index: 2;
+      pointer-events: auto;
     }
     .carousel-slide .overlay {
       margin-top: 1em;
@@ -259,6 +254,15 @@
       .carousel-slide video {
         max-height: 180px;
       }
+      .carousel-slide {
+        width: 90%;
+      }
+      .carousel-slide.prev {
+        transform: translate(-150%, -50%) scale(0.6) rotateY(20deg);
+      }
+      .carousel-slide.next {
+        transform: translate(50%, -50%) scale(0.6) rotateY(-20deg);
+      }
       .fullscreen-toggle-btn {
         top: 10px;
         right: 10px;
@@ -267,10 +271,7 @@
         font-size: 1.1rem;
       }
       .carousel-container {
-        gap: 8px;
-      }
-      .carousel-arrow {
-        margin: 0 4px;
+        gap: 0;
       }
       .fullscreen-arrow {
         width: 40px;
@@ -481,7 +482,6 @@
     <h3>Proyectos</h3>
     <button class="fullscreen-toggle-btn" id="openFullscreenBtn" title="Ver galería en pantalla completa">⛶</button>
     <div class="carousel-container scanlines">
-      <button class="carousel-arrow left" onclick="moveSlide(-1)">&#8592;</button>
       <div class="carousel-slider" id="carouselSlider">
         <!-- Pixel Art -->
         <div class="carousel-slide">
@@ -832,7 +832,6 @@
           </div>
         </div>
       </div>
-      <button class="carousel-arrow right" onclick="moveSlide(1)">&#8594;</button>
     </div>
   </section>
   <section>
@@ -898,24 +897,25 @@
   </section>
   <script>
     // Carousel logic
-    const slides = Array.from(document.querySelectorAll('.carousel-slide'));
+    const slides = Array.from(document.querySelectorAll(".carousel-slide"));
     let currentSlide = 0;
 
-    function showSlide(index) {
-      slides.forEach((slide, i) => {
-        slide.classList.toggle('active', i === index);
-      });
+    function updateCarousel() {
+      slides.forEach(s => s.classList.remove("active","prev","next"));
+      const prev = (currentSlide - 1 + slides.length) % slides.length;
+      const next = (currentSlide + 1) % slides.length;
+      slides[currentSlide].classList.add("active");
+      slides[prev].classList.add("prev");
+      slides[next].classList.add("next");
     }
 
     function moveSlide(direction) {
-      currentSlide += direction;
-      if (currentSlide < 0) currentSlide = slides.length - 1;
-      if (currentSlide >= slides.length) currentSlide = 0;
-      showSlide(currentSlide);
+      currentSlide = (currentSlide + direction + slides.length) % slides.length;
+      updateCarousel();
     }
 
-    // Inicializar
-    showSlide(currentSlide);
+    updateCarousel();
+
 
     // Información de títulos y descripciones para pantalla completa
     const fullscreenData = [
@@ -972,16 +972,15 @@
     // Pantalla completa galería
     let fullscreenIndex = null;
     let fullscreenSlides = [];
-
     function openFullscreenFromCarousel() {
-      fullscreenSlides = Array.from(document.querySelectorAll('.carousel-slide'));
+      fullscreenSlides = slides;
       fullscreenIndex = currentSlide;
       showFullscreenSlide(fullscreenIndex);
       document.getElementById("fullscreen").classList.add("active");
     }
 
     function showFullscreenSlide(idx) {
-      fullscreenSlides = Array.from(document.querySelectorAll('.carousel-slide'));
+      fullscreenSlides = slides;
       if (idx < 0) idx = fullscreenSlides.length - 1;
       if (idx >= fullscreenSlides.length) idx = 0;
       fullscreenIndex = idx;
@@ -1021,21 +1020,18 @@
       fullscreenIndex = null;
     }
 
-    // Click en imagen/video del carrusel
-    document.querySelectorAll(".carousel-slide img").forEach((img, idx) => {
-      img.addEventListener("click", () => {
-        fullscreenSlides = Array.from(document.querySelectorAll('.carousel-slide'));
-        fullscreenIndex = idx;
-        showFullscreenSlide(fullscreenIndex);
-        document.getElementById("fullscreen").classList.add("active");
-      });
-    });
-    document.querySelectorAll(".carousel-slide video").forEach((video, idx) => {
-      video.addEventListener("click", () => {
-        fullscreenSlides = Array.from(document.querySelectorAll('.carousel-slide'));
-        fullscreenIndex = idx;
-        showFullscreenSlide(fullscreenIndex);
-        document.getElementById("fullscreen").classList.add("active");
+    // Click en slides
+    slides.forEach((slide, idx) => {
+      slide.addEventListener("click", () => {
+        if (slide.classList.contains("active")) {
+          fullscreenSlides = slides;
+          fullscreenIndex = idx;
+          showFullscreenSlide(fullscreenIndex);
+          document.getElementById("fullscreen").classList.add("active");
+        } else {
+          currentSlide = idx;
+          updateCarousel();
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
- update carousel markup to show prev/next slides and remove arrows
- style carousel with 3D transforms for active/prev/next
- update JS logic for new carousel interaction
- allow clicking side slides to navigate and center slide to open fullscreen

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c34b0f3a08330bfba9dc584bf4d71